### PR TITLE
docs: Add tagFormat to example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The plugin can be configured in the
 
 ```json
 {
+  "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
This PR will add the `tagFormat` setting to the example usage. The reason for the custom tagFormat is that packagist wants release tags without the "v"-prefix