### PR TITLE
Fix composer.lock warning after semantic release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 [**semantic-release**](https://github.com/semantic-release/semantic-release) plugin to update a
 [composer](https://getcomposer.org/) package for php.
 
-| Step               | Description                                  |
-| ------------------ | -------------------------------------------- |
-| `verifyConditions` | Verify the presence of a composer.json file. |
-| `prepare`          | Update the `composer.json` version           |
+| Step               | Description                                                                |
+| ------------------ | -------------------------------------------------------------------------- |
+| `verifyConditions` | Verify the presence of a composer.json file.                               |
+| `prepare`          | Update the `composer.json` version & sync composer.lock file if it exists. |
 
 ## Install
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { exec } = require("child_process");
+const { execSync } = require("child_process");
 const SemanticReleaseError = require('@semantic-release/error');
 
 let verified;
@@ -54,9 +54,9 @@ async function prepare(pluginConfig, context) {
   const composerLockFile = `${cwd}/composer.lock`;
   if (fs.existsSync(composerLockFile)) {
     // update lock file with new version
-    logger.log('Updating %s for version %s ', composerJsonFile, version);
+    logger.log('Updating %s for version %s ', composerLockFile, version);
 
-    exec('composer update --lock', (error, stdout, stderr) => {
+    execSync('composer update --lock', (error, stdout, stderr) => {
       if (error) {
         logger.error(`composer.lock clould not be updated: ${error.message}`);
         return;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { execSync } = require("child_process");
+const childProcess = require('child_process');
 const SemanticReleaseError = require('@semantic-release/error');
 
 let verified;
@@ -54,22 +54,8 @@ async function prepare(pluginConfig, context) {
   const composerLockFile = `${cwd}/composer.lock`;
   if (fs.existsSync(composerLockFile)) {
     // update lock file with new version
-    logger.log('Updating %s for version %s ', composerLockFile, version);
-
-    execSync('composer update --lock', (error, stdout, stderr) => {
-      if (error) {
-        logger.error(`composer.lock clould not be updated: ${error.message}`);
-        return;
-      }
-      if (stderr) {
-        logger.error(`composer.lock clould not be updated: ${stderr}`);
-        return;
-      }
-      logger.log('Updated composer.lock');
-    });
-  }
-  else {
-    logger.log('composer.lock not found: skipping...');
+    logger.log('Updating version %s in %s ', version, composerLockFile);
+    childProcess.execSync('composer update --lock');
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 const { WritableStreamBuffer } = require('stream-buffers');
 const fs = require('fs');
+const childProcess = require('child_process');
 
 const composerJsonContent = JSON.stringify({
   name: 'ambimax/some-composer-module',
@@ -89,6 +90,8 @@ describe('prepare step', () => {
     const { plugin, context } = setupBefore();
     jest.spyOn(fs, 'existsSync').mockReturnValue(true);
     jest.spyOn(fs, 'readFileSync').mockReturnValue(composerJsonContent);
+    jest.spyOn(childProcess, 'execSync').mockReturnValue(true);
+
     const finalJson = jest.spyOn(fs, 'writeFileSync');
     finalJson.mockImplementation();
     await plugin.prepare(null, context);


### PR DESCRIPTION
# Changes

<!-- Describe your changes here... -->

This PR resolves the warning generated by composer when a semantic version is committed, the code is checked out and the `composer install` command is ran.

```
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>
```
This PR resolves this issue by updating the composer.lock file after the semantic version has been written to the composer.json file using the command `composer update --lock`. So the execution of the semantic release script is as follows:

1. semantic-release-composer updates the composer.json file
2. semantic-release-composer checks that a composer.lock file exists (new)
3. semantic-release-composer runs `composer update --lock` which modifies the composer.lock file (new) 

## Notes on `composer update --lock`

It appears as this command does not update any dependencies as part of its execution, which is desired in this case as we do not want to modify any locked versions of installed packages and just want to keep the composer.lock in sync with the composer.json files.

Source: https://getcomposer.org/doc/03-cli.md#main

```
--lock: Only updates the lock file hash to suppress warning about the lock file being out of date.
```

## Related tickets

- https://github.com/ambimax/semantic-release-composer/issues/14

## PR TODO

<!-- The following todo list should be maintained by you. Please don't remove any bullet points, instead explain why you had to choose a different approach. -->

- [x] I have added required information to README.md
- [x] I have performed a self-review of my own code
- [x] I have updated and referenced related tickets
- [x] My commits contain [Semantic Release syntax](https://guide.ambimax.xyz/best-practices/semantic-release/#git-commits)
